### PR TITLE
Allow setting the GitHub API URL from an environment variable

### DIFF
--- a/lib/coverage/configuration.rb
+++ b/lib/coverage/configuration.rb
@@ -40,6 +40,6 @@ class Configuration
   end
 
   def self.github_api_url
-    ENV["GITHUB_API_URL"] || "https://api.github.com/repos"
+    ENV["GITHUB_API_URL"] || "https://api.github.com"
   end
 end

--- a/lib/coverage/configuration.rb
+++ b/lib/coverage/configuration.rb
@@ -40,6 +40,6 @@ class Configuration
   end
 
   def self.github_api_url
-    "https://api.github.com/repos"
+    ENV["GITHUB_API_URL"] || "https://api.github.com/repos"
   end
 end

--- a/lib/coverage/formatters/end_check_run.rb
+++ b/lib/coverage/formatters/end_check_run.rb
@@ -8,7 +8,7 @@ module Formatters
     end
 
     def as_uri
-      "#{Configuration.github_api_url}/#{Configuration.github_repo}/check-runs/#{@check_id}"
+      "#{Configuration.github_api_url}/repos/#{Configuration.github_repo}/check-runs/#{@check_id}"
     end
 
     def as_payload

--- a/lib/coverage/formatters/start_check_run.rb
+++ b/lib/coverage/formatters/start_check_run.rb
@@ -3,7 +3,7 @@
 module Formatters
   class StartCheckRun
     def self.as_uri
-      "#{Configuration.github_api_url}/#{Configuration.github_repo}/check-runs"
+      "#{Configuration.github_api_url}/repos/#{Configuration.github_repo}/check-runs"
     end
 
     def self.as_payload


### PR DESCRIPTION
Hi.
I was unable to execute this action on GitHub Enterprise because the GitHub URL was hardcoded. 
To make this GitHub Action available from sources other than github.com, I will make changes to allow the URL to be modified via environment variables.
Also, the hardcoded URL includes a path (/repos). In this method, I have made changes to only return the hostname and extract the path (/repos) to where it is being called.