### PR TITLE
Adjust permissions of workflow via Personal Access Token

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,6 +11,7 @@ on:
       - main
 jobs:
   rspec:
+    permissions: write-all
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Permission issue encountered for Pull Requests. Adjusting workflow github_token to utilize personal access token
```
/action/lib/coverage/utils/request.rb:48:in `run': Forbidden: {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/reference/checks#create-a-check-run"} (RuntimeError)
```