### PR TITLE
Allow for configuration status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   debug_mode:
     description: 'Display logs for debugging'
     default: false
+  on_fail_status:
+    description: 'The status to set when coverage fails. You might want neutral if you want things to be informative, for example.'
+    default: 'failure'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/lib/coverage/adapters/github_end_check_payload.rb
+++ b/lib/coverage/adapters/github_end_check_payload.rb
@@ -9,9 +9,9 @@ module Adapters
 
     def conclusion
       if @coverage_detailed_results.enabled? && !@coverage_detailed_results.passed?
-        "failure"
+        Configuration.on_fail_status
       else
-        @coverage_results.passed? ? "success" : "failure"
+        @coverage_results.passed? ? "success" : Configuration.on_fail_status
       end
     end
 

--- a/lib/coverage/configuration.rb
+++ b/lib/coverage/configuration.rb
@@ -19,6 +19,10 @@ class Configuration
     ENV["INPUT_MINIMUM_FILE_COVERAGE"]
   end
 
+  def self.on_fail_status
+    ENV["INPUT_ON_FAIL_STATUS"]
+  end
+
   def self.github_token
     ENV["INPUT_GITHUB_TOKEN"]
   end


### PR DESCRIPTION
This primarily came around as I want to see the set of files with poor code coverage but not necessarily fail the job (but also not pass). This allows for setting the status on fail to neutral

PS - also, awesome project!