### PR TITLE
README fix & WebMock tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Assuming you've followed the guide above (you have the gem in your Gemfile and h
 ## Configuration Options
 See [https://github.com/joshmfrankel/simplecov-check-action/blob/main/action.yml](https://github.com/joshmfrankel/simplecov-check-action/blob/main/action.yml) for all available options and their defaults.
 
-Most useful is the **minimum_coverage** option as it allows specification as to the value at which a failure result should be produced.
+Most useful is the **minimum_suite_coverage** option as it allows specification as to the value at which a failure result should be produced.
 
 ## Advanced Installation
 The advanced installation switches the coverage failing mode from **overall test coverage** to **per file coverage**. This is similiar to the `minimum_coverage_by_file` option that SimpleCov provides. See [minimum_coverage_by_file](https://github.com/simplecov-ruby/simplecov#minimum-coverage-by-file)

--- a/specs/integration/integration_spec.rb
+++ b/specs/integration/integration_spec.rb
@@ -54,7 +54,7 @@ describe "Check Action integration" do
           .to_return(body: { id: check_run_id }.to_json, status: 201)
 
         stub_request(:patch, "https://api.github.com/repos/#{repo}/check-runs/#{check_run_id}")
-          .with(body: { name: "SimpleCov", head_sha: sha, status: "completed", completed_at: the_time, conclusion: "failure", output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
+          .with(body: { name: "SimpleCov", head_sha: sha, status: "completed", completed_at: the_time, conclusion: nil, output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
 
         ClimateControl.modify(
           GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_push.json",
@@ -180,7 +180,7 @@ describe "Check Action integration" do
             .to_return(body: { id: check_run_id }.to_json, status: 201)
 
           stub_request(:patch, "https://api.github.com/repos/#{repo}/check-runs/#{check_run_id}")
-            .with(body: { name: "SimpleCov", head_sha: sha, status: "completed", completed_at: the_time, conclusion: "failure", output: { title: "4 file(s) below minimum #{minimum_file_coverage}.0% coverage", summary: "* 97.77% covered\n" + "* #{minimum_suite_coverage}.0% minimum coverage for suite\n* #{minimum_file_coverage}.0 minimum coverage per file\n", text: failing_markdown_text, annotations: [] } })
+            .with(body: { name: "SimpleCov", head_sha: sha, status: "completed", completed_at: the_time, conclusion: nil, output: { title: "4 file(s) below minimum #{minimum_file_coverage}.0% coverage", summary: "* 97.77% covered\n" + "* #{minimum_suite_coverage}.0% minimum coverage for suite\n* #{minimum_file_coverage}.0 minimum coverage per file\n", text: failing_markdown_text, annotations: [] } })
 
           ClimateControl.modify(
             GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_push.json",
@@ -209,7 +209,7 @@ describe "Check Action integration" do
             .to_return(body: { id: check_run_id }.to_json, status: 201)
 
           stub_request(:patch, "https://api.github.com/repos/#{repo}/check-runs/#{check_run_id}")
-            .with(body: { name: "SimpleCov", head_sha: sha, status: "completed", completed_at: the_time, conclusion: "failure", output: { title: "97.77% covered (minimum #{minimum_suite_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_suite_coverage}.0% minimum coverage for suite\n* #{minimum_file_coverage}.0 minimum coverage per file\n", text: passing_markdown_text, annotations: [] } })
+            .with(body: { name: "SimpleCov", head_sha: sha, status: "completed", completed_at: the_time, conclusion: nil, output: { title: "97.77% covered (minimum #{minimum_suite_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_suite_coverage}.0% minimum coverage for suite\n* #{minimum_file_coverage}.0 minimum coverage per file\n", text: passing_markdown_text, annotations: [] } })
 
           ClimateControl.modify(
             GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_push.json",
@@ -240,7 +240,7 @@ describe "Check Action integration" do
           .to_return(body: { id: check_run_id }.to_json, status: 201)
 
         stub_request(:patch, "https://api.github.com/repos/#{repo}/check-runs/#{check_run_id}")
-          .with(body: { name: "SimpleCov", head_sha: pull_request_json_sha, status: "completed", completed_at: the_time, conclusion: "failure", output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
+          .with(body: { name: "SimpleCov", head_sha: pull_request_json_sha, status: "completed", completed_at: the_time, conclusion: nil, output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
 
         ClimateControl.modify(
           GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_pull_request.json",


### PR DESCRIPTION
First, thank you for your hard work on this project.

I noticed a small change to the README that appears to have been missed on the (80bff957) commit. When I ran the test I was getting `WebMock::NetConnectNotAllowedError` errors. So I've also committed the tweaks that got the specs passing for me. (Please forgive my novice comprehension of WebMock if those changes are in error.)

Finally, please consider adding a small "Development Setup" (or the like) in the README. For example:

## Development Setup
Here's all you'll need to get up and running for local development:
```sh
git clone git@github.com:joshmfrankel/simplecov-check-action.git
cd simplecov-check-action
bundle install
bundle exec rspec spec
```

Thanks again!