### PR TITLE
Use api url from environment (fix for GHES), use debian image, fix specs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.0-alpine
+FROM ruby:3.1.0-slim
 
 COPY lib /action/lib
 

--- a/lib/coverage/configuration.rb
+++ b/lib/coverage/configuration.rb
@@ -44,6 +44,8 @@ class Configuration
   end
 
   def self.github_api_url
-    "https://api.github.com/repos"
+    api_url = ENV.fetch("GITHUB_API_URL", "https://api.github.com")
+
+    "#{api_url}/repos"
   end
 end

--- a/lib/coverage/configuration.rb
+++ b/lib/coverage/configuration.rb
@@ -44,8 +44,6 @@ class Configuration
   end
 
   def self.github_api_url
-    api_url = ENV.fetch("GITHUB_API_URL", "https://api.github.com")
-
-    "#{api_url}/repos"
+    "https://api.github.com/repos"
   end
 end

--- a/specs/integration/integration_spec.rb
+++ b/specs/integration/integration_spec.rb
@@ -13,6 +13,7 @@ describe "Check Action integration" do
   let(:the_time) { "2022-02-21T09:51:57-05:00" }
   let(:repo) { "robswire/immersion" }
   let(:passing_markdown_text) { "No details to show" }
+  let(:on_fail_status) { "failure" }
 
   context "for coverage type line" do
     context "for Pushes" do
@@ -65,7 +66,8 @@ describe "Check Action integration" do
           INPUT_COVERAGE_JSON_PATH: "specs/fakes/xx_not_a_file.json",
           INPUT_MINIMUM_SUITE_COVERAGE: minimum_coverage,
           INPUT_MINIMUM_FILE_COVERAGE: minimum_coverage,
-          INPUT_GITHUB_TOKEN: github_token
+          INPUT_GITHUB_TOKEN: github_token,
+          INPUT_ON_FAIL_STATUS: on_fail_status
         ) do
           CheckAction.new.call
         end
@@ -191,7 +193,8 @@ describe "Check Action integration" do
             INPUT_COVERAGE_JSON_PATH: "specs/fakes/optional_fake_simplecov_json.json",
             INPUT_MINIMUM_SUITE_COVERAGE: minimum_suite_coverage,
             INPUT_MINIMUM_FILE_COVERAGE: minimum_file_coverage,
-            INPUT_GITHUB_TOKEN: github_token
+            INPUT_GITHUB_TOKEN: github_token,
+            INPUT_ON_FAIL_STATUS: on_fail_status
           ) do
             CheckAction.new.call
           end
@@ -220,7 +223,8 @@ describe "Check Action integration" do
             INPUT_COVERAGE_JSON_PATH: "specs/fakes/optional_fake_simplecov_json.json",
             INPUT_MINIMUM_SUITE_COVERAGE: minimum_suite_coverage,
             INPUT_MINIMUM_FILE_COVERAGE: minimum_file_coverage,
-            INPUT_GITHUB_TOKEN: github_token
+            INPUT_GITHUB_TOKEN: github_token,
+            INPUT_ON_FAIL_STATUS: on_fail_status
           ) do
             CheckAction.new.call
           end
@@ -251,7 +255,8 @@ describe "Check Action integration" do
           INPUT_COVERAGE_JSON_PATH: "specs/fakes/xx_not_a_file.json",
           INPUT_MINIMUM_SUITE_COVERAGE: minimum_coverage,
           INPUT_MINIMUM_FILE_COVERAGE: minimum_coverage,
-          INPUT_GITHUB_TOKEN: github_token
+          INPUT_GITHUB_TOKEN: github_token,
+          INPUT_ON_FAIL_STATUS: on_fail_status
         ) do
           CheckAction.new.call
         end


### PR DESCRIPTION
Hi, this is a fix for using Github Enterprise Server API url.  I've also updated the Dockerfile to use the slim image as opposed to alpine.  My environment has DNS issues related to alpine images, this is a well [documented](https://stackoverflow.com/questions/65181012/does-alpine-have-known-dns-issue-within-kubernetes) issue that has to do with alpines use of `musl` C library.

I've also fixed the specs, whose failure was unrelated to this PR.  