### PR TITLE
Allow the configuration of the github repository api url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   on_fail_status:
     description: 'The status to set when coverage fails. You might want neutral if you want things to be informative, for example.'
     default: 'failure'
+  github_repo_api_url:
+    description: 'The github repo api url'
+    default: 'https://api.github.com/repos'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/lib/coverage/configuration.rb
+++ b/lib/coverage/configuration.rb
@@ -43,7 +43,7 @@ class Configuration
     ENV["INPUT_CHECK_JOB_NAME"]
   end
 
-  def self.github_api_url
-    "https://api.github.com/repos"
+  def self.github_repo_api_url
+    ENV["INPUT_GITHUB_REPO_API_URL"]
   end
 end

--- a/lib/coverage/formatters/end_check_run.rb
+++ b/lib/coverage/formatters/end_check_run.rb
@@ -8,7 +8,7 @@ module Formatters
     end
 
     def as_uri
-      "#{Configuration.github_api_url}/#{Configuration.github_repo}/check-runs/#{@check_id}"
+      "#{Configuration.github_repo_api_url}/#{Configuration.github_repo}/check-runs/#{@check_id}"
     end
 
     def as_payload

--- a/lib/coverage/formatters/start_check_run.rb
+++ b/lib/coverage/formatters/start_check_run.rb
@@ -3,7 +3,7 @@
 module Formatters
   class StartCheckRun
     def self.as_uri
-      "#{Configuration.github_api_url}/#{Configuration.github_repo}/check-runs"
+      "#{Configuration.github_repo_api_url}/#{Configuration.github_repo}/check-runs"
     end
 
     def self.as_payload


### PR DESCRIPTION
A configurable github url is required for github enterprise installation where the github url is different from github.com