### PR TITLE
Ensure Configuration defaults contain programmatic fallback in additi…

### DIFF
--- a/lib/coverage/configuration.rb
+++ b/lib/coverage/configuration.rb
@@ -3,32 +3,32 @@
 # Provides simple interface for all configuration and environmental settings
 class Configuration
   def self.coverage_path
-    ENV["INPUT_COVERAGE_PATH"]
+    ENV.fetch('INPUT_COVERAGE_PATH', 'coverage/.last_run.json')
   end
 
   def self.coverage_json_path
-    ENV["INPUT_COVERAGE_JSON_PATH"]
+    ENV.fetch('INPUT_COVERAGE_JSON_PATH', 'coverage/coverage.json')
   end
 
   def self.minimum_suite_coverage
-    ENV["INPUT_MINIMUM_SUITE_COVERAGE"]
+    ENV.fetch('INPUT_MINIMUM_SUITE_COVERAGE', '90')
   end
 
   # Requires simplecov-json results
   def self.minimum_file_coverage
-    ENV["INPUT_MINIMUM_FILE_COVERAGE"]
+    ENV.fetch('INPUT_MINIMUM_FILE_COVERAGE', '70')
   end
 
   def self.on_fail_status
-    ENV["INPUT_ON_FAIL_STATUS"]
+    ENV.fetch('INPUT_ON_FAIL_STATUS', 'failure')
   end
 
   def self.github_token
-    ENV["INPUT_GITHUB_TOKEN"]
+    ENV['INPUT_GITHUB_TOKEN']
   end
 
   def self.github_repo
-    ENV["GITHUB_REPOSITORY"]
+    ENV['GITHUB_REPOSITORY']
   end
 
   def self.github_sha
@@ -36,14 +36,14 @@ class Configuration
   end
 
   def self.debug_mode?
-    ENV["INPUT_DEBUG_MODE"] == "true"
+    ENV['INPUT_DEBUG_MODE'] == 'true'
   end
 
   def self.check_job_name
-    ENV["INPUT_CHECK_JOB_NAME"]
+    ENV.fetch('INPUT_CHECK_JOB_NAME', 'SimpleCov')
   end
 
   def self.github_repo_api_url
-    ENV.fetch("INPUT_GITHUB_REPO_API_URL", "https://api.github.com/repos")
+    ENV.fetch('INPUT_GITHUB_REPO_API_URL', 'https://api.github.com/repos')
   end
 end

--- a/specs/integration/integration_spec.rb
+++ b/specs/integration/integration_spec.rb
@@ -1,68 +1,69 @@
 # frozen_string_literal: true
 
-require "./specs/spec_helper"
+require './specs/spec_helper'
 
-describe "Check Action integration" do
-  let(:github_token) { "hzI7onpyGIGAjg==" }
+describe 'Check Action integration' do
+  let(:github_token) { 'hzI7onpyGIGAjg==' }
   let(:check_run_id) { 1 }
-  let(:sha) { "foobarbaz" }
+  let(:sha) { 'foobarbaz' }
 
-  # Note: This must match sha key in fake
+  # NOTE: This must match sha key in fake
   # @see specs/fakes/fake_github_event_path_pull_request.json
-  let(:pull_request_json_sha) { "3f2dc54bfec0b5295c6" }
-  let(:the_time) { "2022-02-21T09:51:57-05:00" }
-  let(:repo) { "robswire/immersion" }
-  let(:passing_markdown_text) { "No details to show" }
+  let(:pull_request_json_sha) { '3f2dc54bfec0b5295c6' }
+  let(:the_time) { '2022-02-21T09:51:57-05:00' }
+  let(:repo) { 'robswire/immersion' }
+  let(:passing_markdown_text) { 'No details to show' }
 
-  context "for coverage type line" do
-    context "for Pushes" do
+  context 'for coverage type line' do
+    context 'for Pushes' do
       it "raises RuntimeError when coverage file doesn't contain `line` key" do
         mock_time = instance_double(Time)
         expect(Time).to receive(:now).and_return(mock_time)
         expect(mock_time).to receive(:iso8601).and_return(the_time)
-        minimum_coverage = "100"
+        minimum_coverage = '100'
 
         stub_request(:post, "https://api.github.com/repos/#{repo}/check-runs")
-          .with(body: { name: "SimpleCov", head_sha: sha, status: "in_progress", started_at: the_time })
+          .with(body: { name: 'SimpleCov', head_sha: sha, status: 'in_progress', started_at: the_time })
           .to_return(body: { id: check_run_id }.to_json, status: 201)
 
         ClimateControl.modify(
-          GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_push.json",
+          GITHUB_EVENT_PATH: 'specs/fakes/fake_github_event_path_push.json',
           GITHUB_SHA: sha,
           GITHUB_REPOSITORY: repo,
-          INPUT_CHECK_JOB_NAME: "SimpleCov",
-          INPUT_COVERAGE_PATH: "specs/fakes/fake_bad_format.json",
-          INPUT_COVERAGE_JSON_PATH: "specs/fakes/xx_not_a_file.json",
+          INPUT_CHECK_JOB_NAME: 'SimpleCov',
+          INPUT_COVERAGE_PATH: 'specs/fakes/fake_bad_format.json',
+          INPUT_COVERAGE_JSON_PATH: 'specs/fakes/xx_not_a_file.json',
           INPUT_MINIMUM_SUITE_COVERAGE: minimum_coverage,
           INPUT_MINIMUM_FILE_COVERAGE: minimum_coverage,
           INPUT_GITHUB_TOKEN: github_token
         ) do
-          expect {
+          expect do
             CheckAction.new.call
-          }.to raise_error(RuntimeError)
+          end.to raise_error(RuntimeError)
         end
       end
 
-      it "Fails when coverage is lower than suite minimum" do
+      it 'Fails when coverage is lower than suite minimum' do
         mock_time = instance_double(Time)
         expect(Time).to receive(:now).and_return(mock_time).twice
         expect(mock_time).to receive(:iso8601).and_return(the_time).twice
-        minimum_coverage = "100"
+        minimum_coverage = '100'
 
         stub_request(:post, "https://api.github.com/repos/#{repo}/check-runs")
-          .with(body: { name: "SimpleCov", head_sha: sha, status: "in_progress", started_at: the_time })
+          .with(body: { name: 'SimpleCov', head_sha: sha, status: 'in_progress', started_at: the_time })
           .to_return(body: { id: check_run_id }.to_json, status: 201)
 
         stub_request(:patch, "https://api.github.com/repos/#{repo}/check-runs/#{check_run_id}")
-          .with(body: { name: "SimpleCov", head_sha: sha, status: "completed", completed_at: the_time, conclusion: nil, output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
+          .with(body: { name: 'SimpleCov', head_sha: sha, status: 'completed', completed_at: the_time,
+                        conclusion: 'failure', output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
 
         ClimateControl.modify(
-          GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_push.json",
+          GITHUB_EVENT_PATH: 'specs/fakes/fake_github_event_path_push.json',
           GITHUB_SHA: sha,
           GITHUB_REPOSITORY: repo,
-          INPUT_CHECK_JOB_NAME: "SimpleCov",
-          INPUT_COVERAGE_PATH: "specs/fakes/fake_last_run.json",
-          INPUT_COVERAGE_JSON_PATH: "specs/fakes/xx_not_a_file.json",
+          INPUT_CHECK_JOB_NAME: 'SimpleCov',
+          INPUT_COVERAGE_PATH: 'specs/fakes/fake_last_run.json',
+          INPUT_COVERAGE_JSON_PATH: 'specs/fakes/xx_not_a_file.json',
           INPUT_MINIMUM_SUITE_COVERAGE: minimum_coverage,
           INPUT_MINIMUM_FILE_COVERAGE: minimum_coverage,
           INPUT_GITHUB_TOKEN: github_token
@@ -71,26 +72,27 @@ describe "Check Action integration" do
         end
       end
 
-      it "Passes when coverage is greater than or equal to suite minimum" do
+      it 'Passes when coverage is greater than or equal to suite minimum' do
         mock_time = instance_double(Time)
         expect(Time).to receive(:now).and_return(mock_time).twice
         expect(mock_time).to receive(:iso8601).and_return(the_time).twice
-        minimum_coverage = "80"
+        minimum_coverage = '80'
 
         stub_request(:post, "https://api.github.com/repos/#{repo}/check-runs")
-          .with(body: { name: "SimpleCov", head_sha: sha, status: "in_progress", started_at: the_time })
+          .with(body: { name: 'SimpleCov', head_sha: sha, status: 'in_progress', started_at: the_time })
           .to_return(body: { id: check_run_id }.to_json, status: 201)
 
         stub_request(:patch, "https://api.github.com/repos/#{repo}/check-runs/#{check_run_id}")
-          .with(body: { name: "SimpleCov", head_sha: sha, status: "completed", completed_at: the_time, conclusion: "success", output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
+          .with(body: { name: 'SimpleCov', head_sha: sha, status: 'completed', completed_at: the_time,
+                        conclusion: 'success', output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
 
         ClimateControl.modify(
-          GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_push.json",
+          GITHUB_EVENT_PATH: 'specs/fakes/fake_github_event_path_push.json',
           GITHUB_SHA: sha,
           GITHUB_REPOSITORY: repo,
-          INPUT_CHECK_JOB_NAME: "SimpleCov",
-          INPUT_COVERAGE_PATH: "specs/fakes/fake_last_run.json",
-          INPUT_COVERAGE_JSON_PATH: "specs/fakes/xx_not_a_file.json",
+          INPUT_CHECK_JOB_NAME: 'SimpleCov',
+          INPUT_COVERAGE_PATH: 'specs/fakes/fake_last_run.json',
+          INPUT_COVERAGE_JSON_PATH: 'specs/fakes/xx_not_a_file.json',
           INPUT_MINIMUM_SUITE_COVERAGE: minimum_coverage,
           INPUT_MINIMUM_FILE_COVERAGE: minimum_coverage,
           INPUT_GITHUB_TOKEN: github_token
@@ -99,58 +101,60 @@ describe "Check Action integration" do
         end
       end
 
-      it "prints invalid file when coverage_json_path is invalid and debug_mode is enabled" do
+      it 'prints invalid file when coverage_json_path is invalid and debug_mode is enabled' do
         mock_time = instance_double(Time)
         expect(Time).to receive(:now).and_return(mock_time).twice
         expect(mock_time).to receive(:iso8601).and_return(the_time).twice
-        minimum_coverage = "49" # 50 is lowest in fake file
+        minimum_coverage = '49' # 50 is lowest in fake file
 
         stub_request(:post, "https://api.github.com/repos/#{repo}/check-runs")
-          .with(body: { name: "SimpleCov", head_sha: sha, status: "in_progress", started_at: the_time })
+          .with(body: { name: 'SimpleCov', head_sha: sha, status: 'in_progress', started_at: the_time })
           .to_return(body: { id: check_run_id }.to_json, status: 201)
 
         stub_request(:patch, "https://api.github.com/repos/#{repo}/check-runs/#{check_run_id}")
-          .with(body: { name: "SimpleCov", head_sha: sha, status: "completed", completed_at: the_time, conclusion: "success", output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
+          .with(body: { name: 'SimpleCov', head_sha: sha, status: 'completed', completed_at: the_time,
+                        conclusion: 'success', output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
 
         ClimateControl.modify(
-          GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_push.json",
+          GITHUB_EVENT_PATH: 'specs/fakes/fake_github_event_path_push.json',
           GITHUB_SHA: sha,
           GITHUB_REPOSITORY: repo,
-          INPUT_CHECK_JOB_NAME: "SimpleCov",
-          INPUT_COVERAGE_PATH: "specs/fakes/fake_last_run.json",
-          INPUT_COVERAGE_JSON_PATH: "specs/fakes/xx_not_a_file.json",
+          INPUT_CHECK_JOB_NAME: 'SimpleCov',
+          INPUT_COVERAGE_PATH: 'specs/fakes/fake_last_run.json',
+          INPUT_COVERAGE_JSON_PATH: 'specs/fakes/xx_not_a_file.json',
           INPUT_MINIMUM_SUITE_COVERAGE: minimum_coverage,
           INPUT_MINIMUM_FILE_COVERAGE: minimum_coverage,
           INPUT_GITHUB_TOKEN: github_token,
-          INPUT_DEBUG_MODE: "true"
+          INPUT_DEBUG_MODE: 'true'
         ) do
-          expect {
+          expect do
             CheckAction.new.call
-          }.to output(/specs\/fakes\/xx_not_a_file\.json was not a valid Simplecov-json output file./).to_stdout
+          end.to output(%r{specs/fakes/xx_not_a_file\.json was not a valid Simplecov-json output file.}).to_stdout
         end
       end
 
-      context "when SimpleCov-json coverage file is present" do
-        it "Passes when all file coverages are above minimum" do
+      context 'when SimpleCov-json coverage file is present' do
+        it 'Passes when all file coverages are above minimum' do
           mock_time = instance_double(Time)
           expect(Time).to receive(:now).and_return(mock_time).twice
           expect(mock_time).to receive(:iso8601).and_return(the_time).twice
-          minimum_coverage = "49" # 50 is lowest in fake file
+          minimum_coverage = '49' # 50 is lowest in fake file
 
           stub_request(:post, "https://api.github.com/repos/#{repo}/check-runs")
-            .with(body: { name: "SimpleCov", head_sha: sha, status: "in_progress", started_at: the_time })
+            .with(body: { name: 'SimpleCov', head_sha: sha, status: 'in_progress', started_at: the_time })
             .to_return(body: { id: check_run_id }.to_json, status: 201)
 
           stub_request(:patch, "https://api.github.com/repos/#{repo}/check-runs/#{check_run_id}")
-            .with(body: { name: "SimpleCov", head_sha: sha, status: "completed", completed_at: the_time, conclusion: "success", output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n* #{minimum_coverage}.0 minimum coverage per file\n", text: passing_markdown_text, annotations: [] } })
+            .with(body: { name: 'SimpleCov', head_sha: sha, status: 'completed', completed_at: the_time,
+                          conclusion: 'success', output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n* #{minimum_coverage}.0 minimum coverage per file\n", text: passing_markdown_text, annotations: [] } })
 
           ClimateControl.modify(
-            GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_push.json",
+            GITHUB_EVENT_PATH: 'specs/fakes/fake_github_event_path_push.json',
             GITHUB_SHA: sha,
             GITHUB_REPOSITORY: repo,
-            INPUT_CHECK_JOB_NAME: "SimpleCov",
-            INPUT_COVERAGE_PATH: "specs/fakes/fake_last_run.json",
-            INPUT_COVERAGE_JSON_PATH: "specs/fakes/optional_fake_simplecov_json.json",
+            INPUT_CHECK_JOB_NAME: 'SimpleCov',
+            INPUT_COVERAGE_PATH: 'specs/fakes/fake_last_run.json',
+            INPUT_COVERAGE_JSON_PATH: 'specs/fakes/optional_fake_simplecov_json.json',
             INPUT_MINIMUM_SUITE_COVERAGE: minimum_coverage,
             INPUT_MINIMUM_FILE_COVERAGE: minimum_coverage,
             INPUT_GITHUB_TOKEN: github_token
@@ -159,12 +163,12 @@ describe "Check Action integration" do
           end
         end
 
-        it "Fails when coverage is lower than file minimum and prints failing files" do
+        it 'Fails when coverage is lower than file minimum and prints failing files' do
           mock_time = instance_double(Time)
           expect(Time).to receive(:now).and_return(mock_time).twice
           expect(mock_time).to receive(:iso8601).and_return(the_time).twice
-          minimum_suite_coverage = "49"
-          minimum_file_coverage = "99"
+          minimum_suite_coverage = '49'
+          minimum_file_coverage = '99'
           failing_markdown_text = <<~TEXT
             ### Failed because the following files were below the minimum coverage
             | % | File |
@@ -176,19 +180,20 @@ describe "Check Action integration" do
           TEXT
 
           stub_request(:post, "https://api.github.com/repos/#{repo}/check-runs")
-            .with(body: { name: "SimpleCov", head_sha: sha, status: "in_progress", started_at: the_time })
+            .with(body: { name: 'SimpleCov', head_sha: sha, status: 'in_progress', started_at: the_time })
             .to_return(body: { id: check_run_id }.to_json, status: 201)
 
           stub_request(:patch, "https://api.github.com/repos/#{repo}/check-runs/#{check_run_id}")
-            .with(body: { name: "SimpleCov", head_sha: sha, status: "completed", completed_at: the_time, conclusion: nil, output: { title: "4 file(s) below minimum #{minimum_file_coverage}.0% coverage", summary: "* 97.77% covered\n" + "* #{minimum_suite_coverage}.0% minimum coverage for suite\n* #{minimum_file_coverage}.0 minimum coverage per file\n", text: failing_markdown_text, annotations: [] } })
+            .with(body: { name: 'SimpleCov', head_sha: sha, status: 'completed', completed_at: the_time,
+                          conclusion: 'failure', output: { title: "4 file(s) below minimum #{minimum_file_coverage}.0% coverage", summary: "* 97.77% covered\n" + "* #{minimum_suite_coverage}.0% minimum coverage for suite\n* #{minimum_file_coverage}.0 minimum coverage per file\n", text: failing_markdown_text, annotations: [] } })
 
           ClimateControl.modify(
-            GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_push.json",
+            GITHUB_EVENT_PATH: 'specs/fakes/fake_github_event_path_push.json',
             GITHUB_SHA: sha,
             GITHUB_REPOSITORY: repo,
-            INPUT_CHECK_JOB_NAME: "SimpleCov",
-            INPUT_COVERAGE_PATH: "specs/fakes/fake_last_run.json",
-            INPUT_COVERAGE_JSON_PATH: "specs/fakes/optional_fake_simplecov_json.json",
+            INPUT_CHECK_JOB_NAME: 'SimpleCov',
+            INPUT_COVERAGE_PATH: 'specs/fakes/fake_last_run.json',
+            INPUT_COVERAGE_JSON_PATH: 'specs/fakes/optional_fake_simplecov_json.json',
             INPUT_MINIMUM_SUITE_COVERAGE: minimum_suite_coverage,
             INPUT_MINIMUM_FILE_COVERAGE: minimum_file_coverage,
             INPUT_GITHUB_TOKEN: github_token
@@ -197,27 +202,28 @@ describe "Check Action integration" do
           end
         end
 
-        it "Fails when fallback suite minimum coverage fails" do
+        it 'Fails when fallback suite minimum coverage fails' do
           mock_time = instance_double(Time)
           expect(Time).to receive(:now).and_return(mock_time).twice
           expect(mock_time).to receive(:iso8601).and_return(the_time).twice
-          minimum_suite_coverage = "99"
-          minimum_file_coverage = "0" # Basically disables failing on per file coverage
+          minimum_suite_coverage = '99'
+          minimum_file_coverage = '0' # Basically disables failing on per file coverage
 
           stub_request(:post, "https://api.github.com/repos/#{repo}/check-runs")
-            .with(body: { name: "SimpleCov", head_sha: sha, status: "in_progress", started_at: the_time })
+            .with(body: { name: 'SimpleCov', head_sha: sha, status: 'in_progress', started_at: the_time })
             .to_return(body: { id: check_run_id }.to_json, status: 201)
 
           stub_request(:patch, "https://api.github.com/repos/#{repo}/check-runs/#{check_run_id}")
-            .with(body: { name: "SimpleCov", head_sha: sha, status: "completed", completed_at: the_time, conclusion: nil, output: { title: "97.77% covered (minimum #{minimum_suite_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_suite_coverage}.0% minimum coverage for suite\n* #{minimum_file_coverage}.0 minimum coverage per file\n", text: passing_markdown_text, annotations: [] } })
+            .with(body: { name: 'SimpleCov', head_sha: sha, status: 'completed', completed_at: the_time,
+                          conclusion: 'failure', output: { title: "97.77% covered (minimum #{minimum_suite_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_suite_coverage}.0% minimum coverage for suite\n* #{minimum_file_coverage}.0 minimum coverage per file\n", text: passing_markdown_text, annotations: [] } })
 
           ClimateControl.modify(
-            GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_push.json",
+            GITHUB_EVENT_PATH: 'specs/fakes/fake_github_event_path_push.json',
             GITHUB_SHA: sha,
             GITHUB_REPOSITORY: repo,
-            INPUT_CHECK_JOB_NAME: "SimpleCov",
-            INPUT_COVERAGE_PATH: "specs/fakes/fake_last_run.json",
-            INPUT_COVERAGE_JSON_PATH: "specs/fakes/optional_fake_simplecov_json.json",
+            INPUT_CHECK_JOB_NAME: 'SimpleCov',
+            INPUT_COVERAGE_PATH: 'specs/fakes/fake_last_run.json',
+            INPUT_COVERAGE_JSON_PATH: 'specs/fakes/optional_fake_simplecov_json.json',
             INPUT_MINIMUM_SUITE_COVERAGE: minimum_suite_coverage,
             INPUT_MINIMUM_FILE_COVERAGE: minimum_file_coverage,
             INPUT_GITHUB_TOKEN: github_token
@@ -228,27 +234,29 @@ describe "Check Action integration" do
       end
     end
 
-    context "for Pull Requests" do
-      it "Fails when coverage is lower than minimum" do
+    context 'for Pull Requests' do
+      it 'Fails when coverage is lower than minimum' do
         mock_time = instance_double(Time)
         expect(Time).to receive(:now).and_return(mock_time).twice
         expect(mock_time).to receive(:iso8601).and_return(the_time).twice
-        minimum_coverage = "100"
+        minimum_coverage = '100'
 
         stub_request(:post, "https://api.github.com/repos/#{repo}/check-runs")
-          .with(body: { name: "SimpleCov", head_sha: pull_request_json_sha, status: "in_progress", started_at: the_time })
+          .with(body: { name: 'SimpleCov', head_sha: pull_request_json_sha, status: 'in_progress',
+                        started_at: the_time })
           .to_return(body: { id: check_run_id }.to_json, status: 201)
 
         stub_request(:patch, "https://api.github.com/repos/#{repo}/check-runs/#{check_run_id}")
-          .with(body: { name: "SimpleCov", head_sha: pull_request_json_sha, status: "completed", completed_at: the_time, conclusion: nil, output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
+          .with(body: { name: 'SimpleCov', head_sha: pull_request_json_sha, status: 'completed',
+                        completed_at: the_time, conclusion: 'failure', output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
 
         ClimateControl.modify(
-          GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_pull_request.json",
+          GITHUB_EVENT_PATH: 'specs/fakes/fake_github_event_path_pull_request.json',
           GITHUB_SHA: sha,
           GITHUB_REPOSITORY: repo,
-          INPUT_CHECK_JOB_NAME: "SimpleCov",
-          INPUT_COVERAGE_PATH: "specs/fakes/fake_last_run.json",
-          INPUT_COVERAGE_JSON_PATH: "specs/fakes/xx_not_a_file.json",
+          INPUT_CHECK_JOB_NAME: 'SimpleCov',
+          INPUT_COVERAGE_PATH: 'specs/fakes/fake_last_run.json',
+          INPUT_COVERAGE_JSON_PATH: 'specs/fakes/xx_not_a_file.json',
           INPUT_MINIMUM_SUITE_COVERAGE: minimum_coverage,
           INPUT_MINIMUM_FILE_COVERAGE: minimum_coverage,
           INPUT_GITHUB_TOKEN: github_token
@@ -257,26 +265,28 @@ describe "Check Action integration" do
         end
       end
 
-      it "Passes when coverage is greater than or equal to minimum" do
+      it 'Passes when coverage is greater than or equal to minimum' do
         mock_time = instance_double(Time)
         expect(Time).to receive(:now).and_return(mock_time).twice
         expect(mock_time).to receive(:iso8601).and_return(the_time).twice
-        minimum_coverage = "80"
+        minimum_coverage = '80'
 
         stub_request(:post, "https://api.github.com/repos/#{repo}/check-runs")
-          .with(body: { name: "SimpleCov", head_sha: pull_request_json_sha, status: "in_progress", started_at: the_time })
+          .with(body: { name: 'SimpleCov', head_sha: pull_request_json_sha, status: 'in_progress',
+                        started_at: the_time })
           .to_return(body: { id: check_run_id }.to_json, status: 201)
 
         stub_request(:patch, "https://api.github.com/repos/#{repo}/check-runs/#{check_run_id}")
-          .with(body: { name: "SimpleCov", head_sha: pull_request_json_sha, status: "completed", completed_at: the_time, conclusion: "success", output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
+          .with(body: { name: 'SimpleCov', head_sha: pull_request_json_sha, status: 'completed',
+                        completed_at: the_time, conclusion: 'success', output: { title: "97.77% covered (minimum #{minimum_coverage}.0%)", summary: "* 97.77% covered\n" + "* #{minimum_coverage}.0% minimum coverage for suite\n\n", text: passing_markdown_text, annotations: [] } })
 
         ClimateControl.modify(
-          GITHUB_EVENT_PATH: "specs/fakes/fake_github_event_path_pull_request.json",
+          GITHUB_EVENT_PATH: 'specs/fakes/fake_github_event_path_pull_request.json',
           GITHUB_SHA: sha,
           GITHUB_REPOSITORY: repo,
-          INPUT_CHECK_JOB_NAME: "SimpleCov",
-          INPUT_COVERAGE_PATH: "specs/fakes/fake_last_run.json",
-          INPUT_COVERAGE_JSON_PATH: "specs/fakes/xx_not_a_file.json",
+          INPUT_CHECK_JOB_NAME: 'SimpleCov',
+          INPUT_COVERAGE_PATH: 'specs/fakes/fake_last_run.json',
+          INPUT_COVERAGE_JSON_PATH: 'specs/fakes/xx_not_a_file.json',
           INPUT_MINIMUM_SUITE_COVERAGE: minimum_coverage,
           INPUT_MINIMUM_FILE_COVERAGE: minimum_coverage,
           INPUT_GITHUB_TOKEN: github_token

--- a/specs/lib/coverage/configuration_spec.rb
+++ b/specs/lib/coverage/configuration_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require './specs/spec_helper'
+
+describe Configuration do
+  describe 'matches defaults from action.yml' do
+    it 'uses action.yml default for check_job_name' do
+      ClimateControl.modify(INPUT_CHECK_JOB_NAME: nil) do
+        expect(described_class.check_job_name).to eq('SimpleCov')
+      end
+    end
+
+    it 'uses action.yml default for minimum_suite_coverage' do
+      ClimateControl.modify(INPUT_MINIMUM_SUITE_COVERAGE: nil) do
+        expect(described_class.minimum_suite_coverage).to eq('90')
+      end
+    end
+
+    it 'uses action.yml default for minimum_file_coverage' do
+      ClimateControl.modify(INPUT_MINIMUM_FILE_COVERAGE: nil) do
+        expect(described_class.minimum_file_coverage).to eq('70')
+      end
+    end
+
+    it 'uses action.yml default for coverage_path' do
+      ClimateControl.modify(INPUT_COVERAGE_PATH: nil) do
+        expect(described_class.coverage_path).to eq('coverage/.last_run.json')
+      end
+    end
+
+    it 'uses action.yml default for coverage_json_path' do
+      ClimateControl.modify(INPUT_COVERAGE_JSON_PATH: nil) do
+        expect(described_class.coverage_json_path).to eq('coverage/coverage.json')
+      end
+    end
+
+    it 'uses action.yml default for debug_mode' do
+      ClimateControl.modify(INPUT_DEBUG_MODE: nil) do
+        expect(described_class.debug_mode?).to eq(false)
+      end
+    end
+
+    it 'uses action.yml default for on_fail_status' do
+      ClimateControl.modify(INPUT_ON_FAIL_STATUS: nil) do
+        expect(described_class.on_fail_status).to eq('failure')
+      end
+    end
+
+    it 'uses action.yml default for github_repo_api_url' do
+      ClimateControl.modify(INPUT_GITHUB_REPO_API_URL: nil) do
+        expect(described_class.github_repo_api_url).to eq('https://api.github.com/repos')
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Why

It was noticed on other Pull Requests that the configurations from action.yml (while having defaults) did not properly defaul Env variables for non-ci context. Now uses ENV.fetch where appropriate

# What

* Update Configuration to use fallback values that match actions.yml
* Update test converage to properly test `conclusion` value