### PR TITLE
Use image digest and non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-FROM ruby:3.4.2-slim
+ # ruby:3.4.9-slim-trixie
+FROM ruby@sha256:a842f35cdf2fe24a7523182127c3ce6a4848e77fb50b3a57ec09faa59c96491e
+
+RUN useradd --create-home --shell /bin/bash appuser
 
 COPY lib /action/lib
+
+USER appuser
 
 CMD ["ruby", "/action/lib/main.rb"]


### PR DESCRIPTION
# Why

Improves container security.  Especially important for teams using self hosted runners that may run inside protected networks.

# What

This change: 
- Protects against supply chain attacks by referencing the immutable SHA of the image
- Runs as "appuser" to avoid running container as root
